### PR TITLE
Feature: configurable BigQuery offline store export parquet file size

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -575,8 +575,16 @@ class BigQueryRetrievalJob(RetrievalJob):
 
         parquet_file_size_mb = os.getenv("BQ_EXPORT_PARQUET_FILE_SIZE_MB")
         if parquet_file_size_mb is not None and parquet_file_size_mb.isdigit():
+            parquet_file_size_mb_int = int(parquet_file_size_mb)
+            if parquet_file_size_mb_int >= 1000:
+                raise ValueError(
+                    "The value for the BQ_EXPORT_PARQUET_FILE_SIZE_MB environment variable cannot "
+                    "exceed 1000; however, it was set to %s.",
+                    parquet_file_size_mb_int,
+                )
+
             table_size_in_mb = self.client.get_table(table).num_bytes / 1024 / 1024
-            number_of_files = max(1, table_size_in_mb // int(parquet_file_size_mb))
+            number_of_files = max(1, table_size_in_mb // parquet_file_size_mb_int)
             destination_uris = [
                 f"{self._gcs_path}/{n:0>12}.parquet" for n in range(number_of_files)
             ]

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -576,7 +576,7 @@ class BigQueryRetrievalJob(RetrievalJob):
         parquet_file_size_mb = os.getenv("BQ_EXPORT_PARQUET_FILE_SIZE_MB")
         if parquet_file_size_mb is not None and parquet_file_size_mb.isdigit():
             parquet_file_size_mb_int = int(parquet_file_size_mb)
-            if parquet_file_size_mb_int >= 1000:
+            if parquet_file_size_mb_int > 1000:
                 raise ValueError(
                     "The value for the BQ_EXPORT_PARQUET_FILE_SIZE_MB environment variable cannot "
                     "exceed 1000; however, it was set to %s.",

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -574,12 +574,19 @@ class BigQueryRetrievalJob(RetrievalJob):
         table = self.to_bigquery()
 
         parquet_file_size_mb = os.getenv("BQ_EXPORT_PARQUET_FILE_SIZE_MB")
-        if parquet_file_size_mb is not None and parquet_file_size_mb.isdigit():
+        if parquet_file_size_mb is not None:
+            if not parquet_file_size_mb.isdigit():
+                raise ValueError(
+                    "The value for the BQ_EXPORT_PARQUET_FILE_SIZE_MB environment variable must "
+                    "be a numeric digit, but it was set to: %s",
+                    parquet_file_size_mb,
+                )
+
             parquet_file_size_mb_int = int(parquet_file_size_mb)
             if parquet_file_size_mb_int > 1000:
                 raise ValueError(
                     "The value for the BQ_EXPORT_PARQUET_FILE_SIZE_MB environment variable cannot "
-                    "exceed 1000; however, it was set to %s.",
+                    "exceed 1000; however, it was set to: %s.",
                     parquet_file_size_mb_int,
                 )
 

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -574,7 +574,7 @@ class BigQueryRetrievalJob(RetrievalJob):
         table = self.to_bigquery()
 
         parquet_file_size_mb = os.getenv("BQ_EXPORT_PARQUET_FILE_SIZE_MB")
-        if parquet_file_size_mb is not None:
+        if parquet_file_size_mb is not None and parquet_file_size_mb.isdigit():
             table_size_in_mb = self.client.get_table(table).num_bytes / 1024 / 1024
             number_of_files = max(1, table_size_in_mb // int(parquet_file_size_mb))
             destination_uris = [


### PR DESCRIPTION
It's a hackish solution, but it operates as follows: you specify your expected export Parquet file size in Megabytes through the `BQ_EXPORT_PARQUET_FILE_SIZE_MB` environment variable, the value must not exceed 1000 and should be numeric digit. If you do not set this environment variable, it will default to the previous behavior, allowing the BigQuery exporter function to determine the export file size.