### PR TITLE
Refactor: configurable BigQuery offline store export parquet file size

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 import tempfile
 import uuid
 from datetime import date, datetime, timedelta


### PR DESCRIPTION
Here's the corrected version:

This PR refactors the previous method of specifying the BigQuery export file size through an environment variable. The new implementation utilizes `BigQueryOfflineStoreConfig`, allowing the configuration of the GCS staging file size directly via the Feast configuration file.

An example of cofig:
```yaml
...
offline_store:
  ...
  gcs_staging_file_size_mb: 100
```