### PR TITLE
Ensure that number_of_files is int

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -581,7 +581,7 @@ class BigQueryRetrievalJob(RetrievalJob):
             table_size_in_mb = self.client.get_table(table).num_bytes / 1024 / 1024
             number_of_files = max(
                 1,
-                table_size_in_mb // self.config.offline_store.gcs_staging_file_size_mb,
+                int(table_size_in_mb // self.config.offline_store.gcs_staging_file_size_mb),
             )
             destination_uris = [
                 f"{self._gcs_path}/{n:0>12}.parquet" for n in range(number_of_files)


### PR DESCRIPTION
The `table_size_in_mb = self.client.get_table(table).num_bytes / 1024 / 1024` operation might produce a float.
